### PR TITLE
Add disconnect feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Run the application and follow the prompts to select a serial port. Then type
 commands and press Enter to send them. Responses from the device are printed
 to the screen.
 
+When connected you can use the **Disconnect** button to close the current
+port and choose another one.
+
 ```bash
 cargo run --release
 ```


### PR DESCRIPTION
## Summary
- track which port is currently open
- allow disconnecting from the serial port and refreshing the list
- show the active port and a Disconnect button in the GUI
- document the new functionality

## Testing
- `cargo fmt`
- `cargo check` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68835bfc647c832ea206d274e82157d5